### PR TITLE
Update to new platform for newer PHP

### DIFF
--- a/platform
+++ b/platform
@@ -1,0 +1,1 @@
+early_release


### PR DESCRIPTION
Data at https://morph.io/jamezpolley/albury has an `id` column, data at https://morph.io/planningalerts-scrapers/albury does not. Not sure what could be causing this or if it's a problem (I suspect that it's not a problem)

